### PR TITLE
Update styles for `mintButton` on mobile

### DIFF
--- a/styles/Theme.module.css
+++ b/styles/Theme.module.css
@@ -203,6 +203,10 @@
     padding-bottom: 5%;
   }
 
+  .mintButton {
+    max-width: 100% !important;
+  }
+  
   .infoSide {
     width: 100%;
   }


### PR DESCRIPTION
[`parseIneligibility.ts`](https://github.com/thirdweb-example/nft-drop/blob/main/utils/parseIneligibility.ts) has phrases that are longer then can fit on mobile, button will go off screen on most mobile devices

- added important mintButton styles
```
  .mintButton {
    max-width: 100% !important;
  }
```