### PR TITLE
Option to use the template with custom IPFS gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@thirdweb-dev/chains": "^0.1.13",
     "@thirdweb-dev/react": "^3.14.0",
     "@thirdweb-dev/sdk": "^3.10.22",
+    "@thirdweb-dev/storage": "^1.1.5",
     "class-variance-authority": "^0.6.0",
     "clsx": "^1.2.1",
     "ethers": "^5",

--- a/src/consts/parameters.ts
+++ b/src/consts/parameters.ts
@@ -19,3 +19,6 @@ export const themeConst = "dark";
 export const relayerUrlConst = ""; // OpenZeppelin relayer URL
 export const biconomyApiKeyConst = ""; // Biconomy API key
 export const biconomyApiIdConst = ""; // Biconomy API ID
+
+// Custom IPFS Gateway (e.g: https://<your-domain>/ipfs)
+export const customIpfsGateway = "";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,8 +9,10 @@ import {
   biconomyApiIdConst,
   biconomyApiKeyConst,
   chainConst,
+  customIpfsGateway,
   relayerUrlConst,
 } from "./consts/parameters";
+import { getCustomStorageInterface } from "./utils/getCustomIpfsGateway";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);
@@ -30,9 +32,19 @@ const sdkOptions = getGasless(relayerUrl, biconomyApiKey, biconomyApiId);
 const network = urlParams.get("network") || "ethereum";
 const activeChain = getChainBySlug(network); */
 
+// Use your own custom IPFS gateway
+const ipfsGateway =
+  urlParams.get("customIpfsGateway") || customIpfsGateway || "";
+
+const storageInterface = getCustomStorageInterface(ipfsGateway);
+
 root.render(
   <React.StrictMode>
-    <ThirdwebProvider activeChain={chain} sdkOptions={sdkOptions}>
+    <ThirdwebProvider
+      activeChain={chain}
+      sdkOptions={sdkOptions}
+      storageInterface={storageInterface}
+    >
       <Toaster />
       <App />
     </ThirdwebProvider>

--- a/src/utils/getCustomIpfsGateway.ts
+++ b/src/utils/getCustomIpfsGateway.ts
@@ -1,0 +1,30 @@
+import {
+  type IpfsUploadBatchOptions,
+  ThirdwebStorage,
+  StorageDownloader,
+  IpfsUploader,
+} from "@thirdweb-dev/storage";
+
+export function getCustomStorageInterface(
+  gateway?: string,
+): ThirdwebStorage<IpfsUploadBatchOptions> | undefined {
+  if (!gateway) return undefined;
+
+  // Configure a custom ThirdwebStorage instance
+  const gatewayUrls = {
+    "ipfs://": [
+      gateway,
+      "https://gateway.ipfscdn.io/ipfs/",
+      "https://cloudflare-ipfs.com/ipfs/",
+      "https://ipfs.io/ipfs/",
+    ],
+  };
+  const downloader = new StorageDownloader();
+  const uploader = new IpfsUploader();
+  const storage = new ThirdwebStorage({
+    uploader,
+    downloader,
+    gatewayUrls,
+  });
+  return storage;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,6 +1934,16 @@
     ipfs-unixfs-importer "^7.0.1"
     uuid "^9.0.0"
 
+"@thirdweb-dev/storage@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@thirdweb-dev/storage/-/storage-1.1.5.tgz#aa127adbd0ff23b7acc5221ceb5fde63ebebc4d0"
+  integrity sha512-P1q8P4yUV/EB7cLCbbAgkSqKAV/wbG1Lq/tBruU+Yvr1TplaUfK3gBT7sJBizuob+kCvSXjSQeisQG/duxVQaQ==
+  dependencies:
+    cross-fetch "^3.1.5"
+    form-data "^4.0.0"
+    ipfs-unixfs-importer "^7.0.1"
+    uuid "^9.0.0"
+
 "@thirdweb-dev/wallets@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@thirdweb-dev/wallets/-/wallets-0.3.0.tgz#a815505d6c64bb571807fd52d99c02ac9824f140"


### PR DESCRIPTION
Since the public IPFS gateways are incredibly slow at times, there should be an option to add the custom IPFS gateway to the app.

Usage: `https://link-to-app/?customIpfsGateway=https://your-custom-gateway/ipfs`